### PR TITLE
feat: browser: auto-detect MDC & OpenShift URL

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -4,13 +4,11 @@
 ## How to run the tests
 
 ```
-# Username & Password you can use to login to MDC via oAuth Proxy
+# Login with oc client
+oc login <AUTH_URL> --token <TOKEN>
+# Username & Password you can use to login to MDC/OpenShift via oAuth Proxy
 export OPENSHIFT_USERNAME=<REPLACE_ME>
 export OPENSHIFT_PASSWORD=<REPLACE_ME>
-# URL to MDC instance
-export MDC_URL="https://<REPLACE_ME>"
-# URL to OpenShift Console
-export OPENSHIFT_URL="https://<REPLACE_ME>/console"
 npm test
 ```
 

--- a/browser/test/test_mobile_walkthrough.js
+++ b/browser/test/test_mobile_walkthrough.js
@@ -1,7 +1,5 @@
 const openshiftUsername = process.env.OPENSHIFT_USERNAME
 const openshiftPassword = process.env.OPENSHIFT_PASSWORD
-const openshiftConsoleUrl = process.env.OPENSHIFT_URL
-const { expect } = require('chai')
 const { checkLinks, clickOnElements } = require('../utils/walkthrough')
 
 describe('Test Mobile Walkthrough in Solution Explorer', () => {
@@ -9,6 +7,7 @@ describe('Test Mobile Walkthrough in Solution Explorer', () => {
         // Create anonymous browser window to keep tests isolated
         context = await browser.createIncognitoBrowserContext();
         page = await context.newPage();
+        const openshiftConsoleUrl = global.openshiftConsoleUrl
 
         await Promise.all([
             page.goto(openshiftConsoleUrl),

--- a/browser/utils/bootstrap.js
+++ b/browser/utils/bootstrap.js
@@ -1,5 +1,6 @@
 const puppeteer = require('puppeteer')
 const { expect } = require('chai')
+const { init, resource, TYPE, ACTION } = require('../../common/util/rhmds-api')
 const FAILED_TESTS = {};
 
 const opts = {
@@ -14,10 +15,13 @@ const opts = {
 }
 
 before(async () => {
+    const { openshiftClient, mdcNamespace } = await init()
     global.expect = expect
     global.browser = await puppeteer.launch(opts)
     global.page
     global.context
+    global.mdcUrl = await getMdcUrl(mdcNamespace)
+    global.openshiftConsoleUrl = getOpenShiftConsoleUrl(openshiftClient)
 })
 
 after(() => {
@@ -36,3 +40,12 @@ afterEach(function() {
     FAILED_TESTS[this.currentTest.file] = true;
   }
 });
+
+async function getMdcUrl(ns) {
+  const mdcRoutes = await resource(TYPE.ROUTE, ACTION.GET_ALL, '', ns)
+  return `https://${mdcRoutes.items[0].spec.host}`
+}
+
+function getOpenShiftConsoleUrl(openshiftClient) {
+  return openshiftClient.backend.requestOptions.baseUrl
+}

--- a/browser/utils/bootstrap.js
+++ b/browser/utils/bootstrap.js
@@ -15,12 +15,12 @@ const opts = {
 }
 
 before(async () => {
-    const { openshiftClient, mdcNamespace } = await init()
+    const openshiftClient = await init()
     global.expect = expect
     global.browser = await puppeteer.launch(opts)
     global.page
     global.context
-    global.mdcUrl = await getMdcUrl(mdcNamespace)
+    global.mdcUrl = await getMdcUrl()
     global.openshiftConsoleUrl = getOpenShiftConsoleUrl(openshiftClient)
 })
 
@@ -41,9 +41,10 @@ afterEach(function() {
   }
 });
 
-async function getMdcUrl(ns) {
-  const mdcRoutes = await resource(TYPE.ROUTE, ACTION.GET_ALL, '', ns)
-  return `https://${mdcRoutes.items[0].spec.host}`
+async function getMdcUrl() {
+  // MDC namespace is targeted by default
+  const mdcRoute = await resource(TYPE.ROUTE, ACTION.GET_ALL)
+  return `https://${mdcRoute.items[0].spec.host}`
 }
 
 function getOpenShiftConsoleUrl(openshiftClient) {

--- a/browser/utils/mdc/createApp.js
+++ b/browser/utils/mdc/createApp.js
@@ -1,6 +1,6 @@
-const mdcLoginPageUrl = process.env.MDC_URL
-
 module.exports = async (appName) => {
+    const mdcLoginPageUrl = global.mdcUrl
+
     await page.goto(mdcLoginPageUrl, { waitUntil: ['domcontentloaded', 'networkidle0'] })
     await page.waitForSelector('.toolbar-pf-actions button')
 

--- a/browser/utils/mdc/deleteApp.js
+++ b/browser/utils/mdc/deleteApp.js
@@ -1,6 +1,6 @@
-const mdcLoginPageUrl = process.env.MDC_URL
-
 module.exports = async (appName) => {
+    const mdcLoginPageUrl = global.mdcUrl
+
     await page.goto(mdcLoginPageUrl, { waitUntil: ['domcontentloaded', 'networkidle0'] })
     await page.waitForSelector('.toolbar-pf-actions button')
     // Find app's "Dropdown" button and click on it

--- a/browser/utils/mdc/login.js
+++ b/browser/utils/mdc/login.js
@@ -1,8 +1,8 @@
 const username = process.env.OPENSHIFT_USERNAME
 const password = process.env.OPENSHIFT_PASSWORD
-const mdcLoginPageUrl = process.env.MDC_URL
 
 module.exports = async () => {
+    const mdcLoginPageUrl = global.mdcUrl
     // Create anonymous browser window to keep tests isolated
     context = await browser.createIncognitoBrowserContext();
     page = await context.newPage();

--- a/browser/utils/mdc/openApp.js
+++ b/browser/utils/mdc/openApp.js
@@ -1,6 +1,5 @@
-const mdcLoginPageUrl = process.env.MDC_URL
-
 module.exports = async (appName) => {
+    const mdcLoginPageUrl = global.mdcUrl
     await page.goto(mdcLoginPageUrl, { waitUntil: ['domcontentloaded', 'networkidle0'] })
     await page.waitForSelector('.mobile-client-card')
     await Promise.all([

--- a/common/util/rhmds-api.js
+++ b/common/util/rhmds-api.js
@@ -82,7 +82,7 @@ const init = async () => {
 
   openshiftClient = await OpenshiftClient();
 
-  return { openshiftClient, mdcNamespace }
+  return openshiftClient
 }
 
 const resource = async (type, action, param, namespace = null) => {

--- a/common/util/rhmds-api.js
+++ b/common/util/rhmds-api.js
@@ -81,6 +81,8 @@ const init = async () => {
   await determineMdcNamespace();
 
   openshiftClient = await OpenshiftClient();
+
+  return { openshiftClient, mdcNamespace }
 }
 
 const resource = async (type, action, param, namespace = null) => {


### PR DESCRIPTION
https://issues.jboss.org/browse/AGMS-1111

### What has changed
In order to run the tests, we no longer need to specify MDC or OpenShift console URL. Performing `oc login ...` before running the tests is sufficient.

Environment variables `OPENSHIFT_USERNAME` and `OPENSHIFT_PASSWORD` remained because these are directly used in browser tests

### Verification steps
```
git clone --single-branch --branch AGMS-1111 https://github.com/aerogear/test-suite && cd test-suite/browser
oc login # use our OSD cluster
HEADLESS=false OPENSHIFT_USERNAME=<user> OPENSHIFT_PASSWORD=<password> npm test