### PR TITLE
ci: remove parameters definition from jenkinsfiles

### DIFF
--- a/backend/Jenkinsfile
+++ b/backend/Jenkinsfile
@@ -5,11 +5,6 @@ pipeline {
       label 'psi_rhel8'
     }
   }
-  parameters {
-    string(name: 'OPENSHIFT_USERNAME', defaultValue: 'evals01', description: 'Evals username')
-    password(name: 'OPENSHIFT_PASSWORD', defaultValue: 'Password1', description: 'Evals user password')
-    string(name: 'OPENSHIFT_URL', defaultValue: '', description: 'RHMI cluster to target (https://...)')
-  }
   environment {
     FIREBASE_SERVER_KEY = credentials('firebase-server-key')
     IOS_CERTIFICATE = credentials('ios-push-certificate')

--- a/browser/Jenkinsfile
+++ b/browser/Jenkinsfile
@@ -5,11 +5,6 @@ pipeline {
       label 'psi_rhel8'
     }
   }
-  parameters {
-    string(name: 'OPENSHIFT_USERNAME', defaultValue: 'evals01', description: 'Evals username')
-    password(name: 'OPENSHIFT_PASSWORD', defaultValue: 'Password1', description: 'Evals user password')
-    string(name: 'OPENSHIFT_URL', defaultValue: '', description: 'RHMI cluster to target (https://...)')
-  }
   environment {
     JUNIT_REPORT_STACK = '1'
     JUNIT_REPORT_PATH = 'report.xml'

--- a/device/Jenkinsfile
+++ b/device/Jenkinsfile
@@ -6,11 +6,6 @@ def runIntegrationTests() {
 
 pipeline {
   agent none
-  parameters {
-    string(name: 'OPENSHIFT_USER', defaultValue: 'evals01', description: 'Evals username')
-    password(name: 'OPENSHIFT_PASS', defaultValue: 'Password1', description: 'Evals user password')
-    string(name: 'OPENSHIFT_URL', defaultValue: '', description: 'RHMI cluster to target (https://...)')
-  }
   environment {
     BROWSERSTACK_USER = credentials('browserstack-user')
     BROWSERSTACK_KEY = credentials('browserstack-key')
@@ -83,8 +78,8 @@ pipeline {
         stage('Bind services') {
           steps {
             dir('device') {
-              wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASS', password: OPENSHIFT_PASS]]]) {
-                sh "oc login $OPENSHIFT_URL -u $OPENSHIFT_USER -p ${OPENSHIFT_PASS}"
+              wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASSWORD', password: OPENSHIFT_PASSWORD]]]) {
+                sh "oc login $OPENSHIFT_URL -u $OPENSHIFT_USERNAME -p ${OPENSHIFT_PASSWORD}"
               }
               sh './scripts/prepare.js'
             }

--- a/showcase/Jenkinsfile
+++ b/showcase/Jenkinsfile
@@ -6,11 +6,6 @@ def runIntegrationTests() {
 
 pipeline {
   agent none
-  parameters {
-    string(name: 'OPENSHIFT_USER', defaultValue: 'evals01', description: 'Evals username')
-    password(name: 'OPENSHIFT_PASS', defaultValue: 'Password1', description: 'Evals user password')
-    string(name: 'OPENSHIFT_URL', defaultValue: '', description: 'RHMI cluster to target (https://...)')
-  }
   environment {
     BROWSERSTACK_USER = credentials('browserstack-user')
     BROWSERSTACK_KEY = credentials('browserstack-key')
@@ -36,8 +31,8 @@ pipeline {
         stage('Bind services') {
           steps {
             dir('showcase') {
-              wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASS', password: OPENSHIFT_PASS]]]) {
-                sh "oc login $OPENSHIFT_URL -u $OPENSHIFT_USER -p $OPENSHIFT_PASS"
+              wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASSWORD', password: OPENSHIFT_PASSWORD]]]) {
+                sh "oc login $OPENSHIFT_URL -u $OPENSHIFT_USERNAME -p $OPENSHIFT_PASSWORD"
               }
               sh './scripts/prepare.js'
               stash includes: 'mobile-services.json', name: 'mobile-services'


### PR DESCRIPTION
## Motivation

Parameters defined directly in Jenkinsfile does not play nice with JobDSL. I've moved them to JobDSL definition.