### PR TITLE
fix: replace svcat CLI with oc new-app

### DIFF
--- a/common/util/rhmds-api.js
+++ b/common/util/rhmds-api.js
@@ -176,6 +176,7 @@ const deployShowcaseServer = async (namespace) => {
   await waitFor(async () => {
     const replicasReady = (await exec(`oc get dc -o jsonpath='{.items[*].status.readyReplicas}' -n ${namespace} | wc -w`)).stdout.replace(/\s/g, '')
     console.log(`Still waiting for deployment of Data Sync Template. Replicas ready: ${replicasReady}/3`)
+    // until postgresql, mqtt and showcase-server are ready
     return replicasReady.includes('3')
   }, 200000, 10000)
 };

--- a/common/util/rhmds-api.js
+++ b/common/util/rhmds-api.js
@@ -175,7 +175,7 @@ const deployShowcaseServer = async (namespace) => {
   await exec(`oc new-app --template datasync-showcase-server -n ${namespace}`);
   await waitFor(async () => {
     const replicasReady = (await exec(`oc get dc -o jsonpath='{.items[*].status.readyReplicas}' -n ${namespace} | wc -w`)).stdout.replace(/\s/g, '')
-    console.log(`Still waiting for deployment of Data Sync Template. Replicas ready: ${replicasReady}/3`)
+    console.log(`Waiting for showcase server: ${replicasReady}/3`)
     // until postgresql, mqtt and showcase-server are ready
     return replicasReady.includes('3')
   }, 200000, 10000)

--- a/common/util/rhmds-api.js
+++ b/common/util/rhmds-api.js
@@ -171,14 +171,20 @@ const createPushApp = async name => {
   return pushApp;
 };
 
-const deployShowcaseServer = async (namespace) => {
+const deployShowcaseServer = async namespace => {
   await exec(`oc new-app --template datasync-showcase-server -n ${namespace}`);
-  await waitFor(async () => {
-    const replicasReady = (await exec(`oc get dc -o jsonpath='{.items[*].status.readyReplicas}' -n ${namespace} | wc -w`)).stdout.replace(/\s/g, '')
-    console.log(`Waiting for showcase server: ${replicasReady}/3`)
-    // until postgresql, mqtt and showcase-server are ready
-    return replicasReady.includes('3')
-  }, 200000, 10000)
+  await waitFor(
+    async () => {
+      const replicasReady = (await exec(
+        `oc get dc -o jsonpath='{.items[*].status.readyReplicas}' -n ${namespace} | wc -w`
+      )).stdout.replace(/\s/g, "");
+      console.log(`Waiting for showcase server: ${replicasReady}/3`);
+      // until postgresql, mqtt and showcase-server are ready
+      return replicasReady.includes("3");
+    },
+    200000,
+    10000
+  );
 };
 
 const newProject = async name => {

--- a/containers/node/Dockerfile
+++ b/containers/node/Dockerfile
@@ -20,14 +20,6 @@ RUN tar -xvf oc.tar.gz
 
 RUN mv openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/* /usr/local/bin/
 
-# install svcat cli
-
-ADD https://download.svcat.sh/cli/latest-v0.2/linux/amd64/svcat $HOME/svcat
-
-RUN chmod +x svcat
-
-RUN mv svcat /usr/local/bin/
-
 # create jenkins user
 
 RUN useradd -m -u 1001 jenkins


### PR DESCRIPTION
### Comments

You can verify this change by running the backend test suite against OCP 3.11 with RHMI + RHMDS installed (all tests should pass) or against OCP 4.2 with MDS installed via [mobile-services-installer](https://github.com/aerogear/mobile-services-installer).

**Note:** Not all tests are passing on OCP 4.2, I'm currently investigating why.