### PR TITLE
modified browser/Jenkinsfile for authentication with a token

### DIFF
--- a/browser/Jenkinsfile
+++ b/browser/Jenkinsfile
@@ -32,7 +32,6 @@ pipeline {
     stage('Login with oc') {
       steps {
           sh "oc login --token=$OPENSHIFT_TOKEN --server=$OPENSHIFT_URL"
-        }
       }
     }
     stage('Test') {

--- a/browser/Jenkinsfile
+++ b/browser/Jenkinsfile
@@ -31,7 +31,6 @@ pipeline {
     }
     stage('Login with oc') {
       steps {
-        wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASSWORD', password: OPENSHIFT_PASSWORD]]]) {
           sh "oc login --token=$OPENSHIFT_TOKEN --server=$OPENSHIFT_URL"
         }
       }

--- a/browser/Jenkinsfile
+++ b/browser/Jenkinsfile
@@ -2,6 +2,7 @@
 //   - OPENSHIFT_URL - RHMI cluster to target (https://...)
 //   - OPENSHIFT_USERNAME - cluster-admin username
 //   - OPENSHIFT_PASSWORD - cluster-admin password
+//   - OPENSHIFT_TOKEN - token for logging into the cluster
 
 pipeline {
   agent {
@@ -31,7 +32,7 @@ pipeline {
     stage('Login with oc') {
       steps {
         wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'OPENSHIFT_PASSWORD', password: OPENSHIFT_PASSWORD]]]) {
-          sh "oc login $OPENSHIFT_URL -u $OPENSHIFT_USERNAME -p ${OPENSHIFT_PASSWORD}"
+          sh "oc login --token=$OPENSHIFT_TOKEN --server=$OPENSHIFT_URL"
         }
       }
     }


### PR DESCRIPTION
tested [here](https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/RHMI%202.x/job/ag-browser-tests-RHMI2/), need an OPENSHIFT_TOKEN parameter to be added to [the centralCI repo](https://github.com/RHCloudServices/centralci/blob/master/jobs-dsl/aerogear.groovy)